### PR TITLE
Fix doSave to return correct header on new record

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 Silverstripe 4 version of: https://github.com/briceburg/silverstripe-pickerfield
+With a few extra fixes.

--- a/code/PickerFieldAddExistingSearchHandler.php
+++ b/code/PickerFieldAddExistingSearchHandler.php
@@ -23,7 +23,7 @@ class PickerFieldAddExistingSearchHandler extends GridFieldAddExistingSearchHand
 		}
 
 		// appropriate handling of has_one relationships
-		$childProperty = $this->grid->getName() . 'ID';
+		$childProperty = $this->grid->getName();
 		$this->grid->childObject->$childProperty = $id;
 		$this->grid->childObject->write();
 	}

--- a/code/PickerFieldEditHandler.php
+++ b/code/PickerFieldEditHandler.php
@@ -11,7 +11,8 @@ use SilverStripe\GraphQL\Controller;
 class PickerFieldEditHandler extends GridFieldDetailForm_ItemRequest {
 
 	public function doSave($data, $form) {
-
+        $isNewRecord = $this->record->ID == 0;
+        
 	    /**
 	     * modelled after doSave method on GridFieldDetailForm_ItemRequest
 	     */
@@ -65,7 +66,7 @@ class PickerFieldEditHandler extends GridFieldDetailForm_ItemRequest {
 	    }
 
 
-	    return $this->edit(Controller::curr()->getRequest());
+	    return $this->redirectAfterSave($isNewRecord);
 	}
 
 


### PR DESCRIPTION
Update PickerFieldEditHandler::doSave so that correct x-controllerurl headers are returned to front end so that Add New Record button in the lower right will work after creating a new record with the PickerField.  Without this fix, the URL is not updated to the edit URL of the new record so the Add new record does nothing since it thinks the page is already at the correct URL for creating a new record.